### PR TITLE
 Fix Docker Build and Runtime Issues

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,8 @@
     # Copy built files from builder
     COPY --from=builder /app/dist ./dist
     
-    # If you need to copy other files (like config), add here
+    # Copy config files (JavaScript files not copied by TypeScript build)
+    COPY --from=builder /app/src/config ./dist/config
     
     # Set environment variables if needed
     ENV NODE_ENV=production


### PR DESCRIPTION
## Problem
The Docker build and deployment process was failing due to two critical issues:
Build Failure: Docker build was failing during the production stage with husky installation errors
Runtime Failure: Application was crashing at startup with MODULE_NOT_FOUND errors for config files
Root Cause Analysis
### Issue 1: Husky Installation in Production
The prepare script in package.json was trying to run husky install during production builds
Husky is a dev dependency and not available when running npm ci --omit=dev in production Docker stage
This caused the entire npm install process to fail with exit code 127
### Issue 2: Missing Config Files at Runtime
TypeScript build process (npm run build) only compiles .ts files to .js files
JavaScript config files in src/config/ were not being copied to dist/config/
At runtime, compiled code was trying to require config files that didn't exist in the production container
## Solution
###✅ Fix 1: Graceful Husky Handling
- Modified the prepare script from "husky install" to "husky install || exit 0"
- This allows the script to continue gracefully if husky is not available
- Maintains functionality in development while preventing production build failures
### ✅ Fix 2: Copy Config Files to Production Image
- Added explicit copy command in Dockerfile: COPY --from=builder /app/src/config ./dist/config
- Ensures JavaScript config files are available at runtime in the correct location
- Maintains the multi-stage build optimization while fixing the missing files issue