### PR TITLE
Refactor useNASA hook to remove unused PerseveranceWeatherResponse type

### DIFF
--- a/frontend/src/hooks/useNASA.ts
+++ b/frontend/src/hooks/useNASA.ts
@@ -11,8 +11,7 @@ import {
   type MarsRoverResponse, 
   type RoverManifest, 
   type MostActiveRoverResponse,
-  type RoverName,
-  type PerseveranceWeatherResponse
+  type RoverName
 } from '@/services/nasa'
 
 // Query Keys


### PR DESCRIPTION
- Eliminated the import of PerseveranceWeatherResponse from the useNASA hook, streamlining the code and focusing on relevant types for NASA API integration.